### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -5,6 +5,7 @@ import "reflect"
 
 type Formal struct {
 	FormalApiKey string `mapstructure:"formal-api-key"`
+	BaseUrl      string `mapstructure:"base-url"`
 }
 
 func (c *Formal) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,8 +13,16 @@ var (
 		field.WithRequired(true),
 	)
 
+	BaseUrlField = field.StringField(
+		"base-url",
+		field.WithDescription("Override the Formal API URL (for testing)"),
+		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
+	)
+
 	ConfigurationFields = []field.SchemaField{
 		FormalAPIKeyField,
+		BaseUrlField,
 	}
 
 	FieldRelationships = []field.SchemaFieldRelationship{}

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -47,7 +47,13 @@ func (d *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 
 // New returns a new instance of the connector.
 func New(ctx context.Context, cc *cfg.Formal, opts *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
+	var client *sdk.FormalSDK
+	if cc.BaseUrl != "" {
+		client = sdk.NewWithUrl(cc.FormalApiKey, cc.BaseUrl)
+	} else {
+		client = sdk.New(cc.FormalApiKey)
+	}
 	return &Connector{
-		client: sdk.New(cc.FormalApiKey),
+		client: client,
 	}, nil, nil
 }


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-formal/main.go,pkg/connector/connector.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-formal --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable base URL parameter to Connector initialization, allowing users to specify custom API endpoints for different environments and deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->