### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/formal.go
+++ b/pkg/connector/formal.go
@@ -25,10 +25,10 @@ func formalUserToResourceUser(parentResourceID *v2.ResourceId, user *corev1.User
 
 	return sdkResource.NewUserResource(name, userResourceType, userID, []sdkResource.UserTraitOption{
 		sdkResource.WithEmail(email, true),
-		sdkResource.WithCreatedAt(createdAt),
 		sdkResource.WithAccountType(userType),
-		sdkResource.WithStatus(v2.UserTrait_Status_STATUS_ENABLED),
-	}, sdkResource.WithParentResourceID(parentResourceID))
+	},
+		sdkResource.WithResourceCreatedAt(createdAt),
+		sdkResource.WithResourceStatus(v2.Status_RESOURCE_STATUS_ENABLED, ""), sdkResource.WithParentResourceID(parentResourceID))
 }
 
 func formalGroupToResourceGroup(parentResourceID *v2.ResourceId, group *corev1.Group) (*v2.Resource, error) {
@@ -36,14 +36,13 @@ func formalGroupToResourceGroup(parentResourceID *v2.ResourceId, group *corev1.G
 		group.GetName(),
 		groupResourceType,
 		group.GetId(),
-		[]sdkResource.GroupTraitOption{
-			sdkResource.WithGroupProfile(map[string]interface{}{
-				"created_at":     group.GetCreatedAt().AsTime().Unix(),
-				"updated_at":     group.GetUpdatedAt().AsTime().Unix(),
-				"dsync_group_id": group.GetDsyncGroupId(),
-				"description":    group.GetDescription(),
-			}),
-		},
+		[]sdkResource.GroupTraitOption{},
+		sdkResource.WithResourceProfile(map[string]interface{}{
+			"created_at":     group.GetCreatedAt().AsTime().Unix(),
+			"updated_at":     group.GetUpdatedAt().AsTime().Unix(),
+			"dsync_group_id": group.GetDsyncGroupId(),
+			"description":    group.GetDescription(),
+		}),
 		sdkResource.WithParentResourceID(parentResourceID),
 	)
 }


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
